### PR TITLE
Document stack and plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,55 @@
 # Interactive Table
 
-A Vite + React starter for building an interactive CSV inspection experience.
+An interactive table experience for data exploration, lightweight archival, and rich inspection of user-supplied CSV data.
 
-## Next steps
+## Overview
 
-1. Choose the stack.
-2. Sketch the architecture.
-3. Document the plan.
+- Users upload tabular data, review it in a high-performing grid, and keep their last dataset in the browser for fast reopen.
+- The experience should stay responsive on large datasets by virtualizing rendering and delegating expensive work to hooks/services.
+- We ship through GitHub Pages so the experience can be previewed without additional infrastructure.
+
+## Technology stack
+
+- **React 18 + TypeScript** – component architecture with hooks, contexts, and strongly typed contracts for the core table, data loaders, and controls.
+- **Vite 5** – zero-config dev server, fast build, and native support for GitHub Pages-friendly static exports.
+- **Persisted data service** – a hook-based service manages parsing, validation, derived metadata, and mirrors the latest dataset + filters into `localStorage`.
+- **CSS + layout strategy** – scoped CSS modules (or plain `.css` files for now) with CSS variables to control spacing, typography, and theming helpers.
+- **Testing via Vitest + Testing Library** – unit tests for hooks/services and lightweight integration tests for rendering + interaction flows.
+
+## Architectural overview
+
+1. **Entry & shell** (`src/main.tsx` → `App`) wires React into the DOM, bootstraps providers (data, UI preferences), and owns the high-level layout (toolbar + table + detail drawer).
+2. **Toolbar + controls** handle file uploads, column visibility toggles, sort/filter selectors, and export actions. Controls emit intent that the data service sanitizes.
+3. **Data service & hooks** expose APIs such as `useCSVData`, `useSortedData`, and `useColumnVisibility`. The service parses CSV asynchronously, detects schema mismatches, and caches derived summaries (counts, ranges).
+4. **Table viewport** renders headers and rows with virtualization (windowing or `IntersectionObserver` guards) so we only paint visible rows. It also surfaces a detail drawer or sidebar for the selected row.
+5. **Persistence layer** mirrors the latest dataset, filters, and column toggles into `localStorage` so returning visitors resume where they left off. The service also exposes `reset` commands for QA.
+6. **Feature layering** keeps heavy lifting (sorting, filtering, virtualization) inside composable hooks, so we can unit test each concern and keep the UI lean.
+
+## Issue roadmap & acceptance criteria
+
+| Issue | Focus | Acceptance criteria |
+| --- | --- | --- |
+| **#1 (this issue)** | Stack, architecture, and plan | README and docs capture the chosen stack, architecture overview, issue roadmap with readiness criteria, and a GitHub Pages deployment plan (this document and `docs/plan.md` cover the work). |
+| **#2: CSV ingestion & persistence** | Upload, parse, and store datasets | Users can upload CSV/TSV, the service validates headers, stores parsed rows in memory, echoes metadata (row count, column types), and mirrors the dataset + UI state to `localStorage`. Unit tests cover parsing logic. |
+| **#3: Interactivity & virtualization** | Sorting, filtering, virtualization, and column controls | Table can sort/filter on at least two column types, virtualization keeps frame rate smooth on 1,000+ rows, and column toggles + export buttons update the service consistently. Integration tests exercise the main toolbar + viewport interactions. |
+| **#4: Release & QA automation** | CI/CD, GitHub Pages, and polish | `npm run build` runs in CI, GitHub Actions deploy `dist/` to `gh-pages`, README explains how to visit the live site, and we have at least one smoke test verifying the public build.
+
+For more detail on how these issues break down into tasks, dependencies, and readiness checks, see [`docs/plan.md`](./docs/plan.md).
+
+## Deployment plan (GitHub Pages)
+
+1. The production build lives in `dist/`, created by `npm run build` (Vite handles modern bundling).
+2. We deploy via `gh-pages`, either by configuring the `gh-pages` branch manually or by using `peaceiris/actions-gh-pages` in a GitHub Actions workflow.
+3. The workflow triggers on pushes to `main` (and on demand for previews), runs `npm ci` → `npm run build`, and publishes `dist/` to `gh-pages` with a deterministic commit.
+4. Site visitors access `https://mdklab.github.io/interactive-table` (the URL updates automatically when GitHub Pages deployment succeeds).
+5. We continue to run `npm run dev` or `npm run preview` locally for manual testing before each deployment.
+
+## Testing & quality
+
+- `npm run test` exercises Vitest suites, including hook logic and any render snapshots we add.
+- PRs should keep scope small, add targeted tests for new interactions, and uphold accessibility best practices (keyboard focus, labels, announcements).
+- We rely on the layered architecture to keep logic testable—business rules live in hooks/services rather than in sprawling components.
+
+## Detailed plan
+
+See [`docs/plan.md`](./docs/plan.md) for the architecture timeline, readiness criteria for follow-on issues, deployment steps, and definition-of-done checklists.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,44 @@
+# Implementation plan
+
+This document expands on Issue #1 by clarifying how we move from stack decisions to an interactive, deployable experience. It highlights the work breakdown, acceptance criteria, and deployment details.
+
+## Completed work (Issue #1: Stack + plan)
+
+- Chose React 18 + TypeScript + Vite, explained the persistence strategy, and committed the core architectural ideas to `README.md`.
+- Captured the issue roadmap plus readiness criteria in `README.md`'s table.
+- Documented the GitHub Pages deployment playbook so future issues know how release works.
+
+## Issue breakdown
+
+| Issue | Outcome focus | Acceptance criteria |
+| --- | --- | --- |
+| **#1: Stack & plan (current)** | Foundation | This document, `README.md`, and the deployment notes capture the stack, architecture, issue roadmap, and GhPages plan. |
+| **#2: CSV ingestion & persistence** | File uploads & storage | Upload flow accepts CSV/TSV, validates headers, parses rows asynchronously, buffers a summary (row count, column types), and mirrors data + UI state into `localStorage`. Hook-level tests prove parsing + persistence. |
+| **#3: Interactivity & virtualization** | Sorting, filtering, controls | The toolbar exposes sort/filter toggles, column visibility, and export actions; the table uses virtualization to stay responsive on 1,000+ rows; integration tests cover the toolbar + viewport interactions. |
+| **#4: Release automation & QA** | CI/CD, GH Pages, polish | GitHub Actions runs `npm ci && npm run build`, publishes the `dist/` folder to `gh-pages`, and the README links to the live URL. Smoke tests confirm the deployed build renders the main view. |
+
+Additional issues will be created once the above acceptance criteria are met and will cover: accessibility improvements, analytics/telemetry, design system polish, or data export enhancements. Each new issue will include a definition of done and QA checklist before merging.
+
+## GitHub Pages deployment plan
+
+1. **Build configuration** – `npm run build` (Vite) emits static `dist/` assets. Keep `homepage` or router configuration minimal so we ship a static SPA.
+2. **Workflow** – Add a GitHub Actions workflow (e.g., `.github/workflows/deploy.yml`) that triggers on pushes to `main` and optionally on pulls. Steps:
+   - `npm ci`
+   - `npm run build`
+   - `peaceiris/actions-gh-pages@v4` (or equivalent) deploys `dist/` to the `gh-pages` branch using a token tied to the repo.
+3. **Branch strategy** – The `gh-pages` branch becomes the deployment target. The workflow pushes built assets there; the live site is then `https://mdklab.github.io/interactive-table`.
+4. **Verification** – After deployment we run a smoke test (locally or via GitHub Actions) that fetches the published URL and ensures the table shell renders.
+5. **Rollback & monitoring** – Issues mention `gh-pages` history, so we can roll back by re-deploying a previous commit if the new build misbehaves.
+
+## Quality & readiness
+
+- We rely on hook/service testing (Vitest + Testing Library) to verify parsers, filters, and virtualization helpers, keeping UI tests lightweight.
+- Each issue will include a `Definition of Done` section in its description with clear acceptance criteria and verification steps.
+- Documentation (README + docs/) will stay synced with the code—if deployment changes, the README updates too.
+
+## Next steps
+
+1. Implement Issue #2 (data ingestion) with a failing test first, then wiring the toolbar.
+2. Layer Issue #3 (interactions & virtualization), keeping logic in pure hooks for testability.
+3. Set up GitHub Actions and GH Pages deployment for Issue #4 before the first release.
+4. Add instrumentation (e.g., analytics placeholders) once the core table is stable.


### PR DESCRIPTION
## Summary\n- capture the chosen stack, architecture overview, and issue roadmap for the interactive table experience\n- record the deployment and readiness plan in README.md and docs/plan.md\n\n## Testing\n- Not run (documentation changes only)\n\nFixes #1