### PR TITLE
Add interactive table virtualization

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,37 +1,300 @@
+:root {
+  --panel-background: #ffffff;
+  --panel-border: rgba(11, 31, 58, 0.12);
+  --panel-radius: 1.25rem;
+  --panel-shadow: 0 18px 40px rgba(12, 39, 74, 0.08);
+}
+
 .app-shell {
   min-height: 100vh;
-  padding: 2.5rem 1.5rem;
-  background: radial-gradient(circle at top, rgba(13, 59, 102, 0.2), transparent 50%), #f4f7fb;
+  padding: 2.5rem 1.5rem 3rem;
+  background: radial-gradient(circle at top, rgba(11, 31, 58, 0.25), transparent 40%), #f4f7fb;
   color: #0b1f3a;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.75rem;
+}
+
+.hero {
+  max-width: 56rem;
+}
+
+.eyebrow {
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  margin: 0;
+  color: #53607a;
 }
 
 .hero h1 {
-  font-size: clamp(2.2rem, 2.8vw, 3rem);
-  margin: 0.35rem 0;
+  font-size: clamp(2.2rem, 3vw, 3rem);
+  margin: 0.35rem 0 0.75rem;
   line-height: 1.2;
 }
 
 .hero p {
-  max-width: 45ch;
   margin: 0;
+  max-width: 48ch;
   color: #2b3a54;
 }
 
-.feature-list ul {
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.25rem;
+}
+
+.panel {
+  background: var(--panel-background);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--panel-radius);
+  padding: 1.5rem;
+  box-shadow: var(--panel-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel-heading h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.25rem;
+}
+
+.panel-heading p {
+  margin: 0;
+  color: #54607a;
+  font-size: 0.95rem;
+}
+
+.file-input {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.9rem 1.2rem;
+  border-radius: 0.85rem;
+  background: #0b1f3a;
+  color: #f4f7fb;
+  font-weight: 600;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+}
+
+.file-input input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.helper-text {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #4b566f;
+}
+
+.status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #0b1f3a;
+}
+
+.status-error {
+  color: #c53c44;
+}
+
+.status-info {
+  color: #1d5eb8;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.summary-grid .label {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #54607a;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+}
+
+.summary-grid .value {
+  margin: 0.3rem 0 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.preview-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  margin-top: 0.2rem;
+}
+
+.preview-control select {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(11, 31, 58, 0.3);
+  padding: 0.35rem 0.6rem;
+  background: #fff;
+  font-size: 0.9rem;
+}
+
+.column-meta {
   list-style: none;
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.75rem;
+  gap: 0.65rem;
 }
 
-.feature-list li {
-  background: #fff;
+.column-meta li {
+  display: grid;
+  grid-template-columns: 1.5fr 0.8fr 1fr;
+  gap: 0.5rem;
+  padding: 0.65rem 0.9rem;
   border-radius: 0.75rem;
-  padding: 0.85rem 1.1rem;
-  border: 1px solid rgba(11, 31, 58, 0.15);
-  box-shadow: 0 12px 30px rgba(15, 40, 80, 0.08);
+  background: #f7f9fc;
+}
+
+.column-name {
+  font-weight: 600;
+}
+
+.column-type {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #54607a;
+}
+
+.column-sample {
+  text-align: right;
+  color: #1d5eb8;
+  font-size: 0.9rem;
+}
+
+.filtered-state {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #33415c;
+}
+
+.panel.preview-panel {
+  background: #fff;
+}
+
+.table-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.table-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: #54607a;
+}
+
+.table-filter input {
+  border-radius: 0.85rem;
+  border: 1px solid rgba(11, 31, 58, 0.25);
+  padding: 0.55rem 0.9rem;
+  font-size: 0.95rem;
+  min-width: 220px;
+  background: #fdfdfd;
+}
+
+.row-count {
+  margin: 0;
+  color: #2b3a54;
+  font-weight: 600;
+}
+
+.table-viewport {
+  overflow-y: auto;
+  border-radius: 0.95rem;
+  border: 1px solid rgba(11, 31, 58, 0.12);
+  margin-top: 0.5rem;
+  background: #fff;
+}
+
+.table-viewport table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.table-viewport th,
+.table-viewport td {
+  padding: 0.65rem 0.85rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(11, 31, 58, 0.08);
+}
+
+.table-viewport th {
+  background: rgba(11, 31, 58, 0.05);
+}
+
+.table-viewport tr:last-of-type td {
+  border-bottom: none;
+}
+
+.column-sort {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  width: 100%;
+  cursor: pointer;
+  padding: 0;
+}
+
+.column-sort:focus-visible {
+  outline: 2px solid #1d5eb8;
+  outline-offset: 2px;
+}
+
+.column-sort.is-sorted {
+  font-weight: 600;
+}
+
+.sort-indicator {
+  font-size: 0.75rem;
+  color: #54607a;
+}
+
+.spacer-row td {
+  padding: 0;
+  border: none;
+}
+
+.placeholder {
+  margin: 0;
+  color: #5b647d;
+}
+
+@media (max-width: 640px) {
+  .column-meta li {
+    grid-template-columns: 1fr;
+  }
+
+  .table-filter input {
+    min-width: 0;
+    width: 100%;
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,32 +1,275 @@
+import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import "./App.css";
+import { useTableState } from "./hooks/useTableState";
+import { filterRows, sortRows, type SortDirection } from "./utils/tableData";
 
-const features = [
-  "CSV uploads with validation",
-  "Column sorting and filtering",
-  "Lazy rendering for large datasets",
-  "GitHub Pages-ready deployments",
-];
+const PREVIEW_OPTIONS = [3, 5, 10];
+const ROW_HEIGHT = 44;
+const VIRTUAL_BUFFER_ROWS = 6;
+
+type SortState = { columnIndex: number; direction: SortDirection };
 
 export default function App() {
+  const { state, uploadDataset, updatePreviewCount, loading, error } = useTableState();
+  const dataset = state.dataset;
+  const previewCount = state.ui.previewRowCount;
+
+  const [filterQuery, setFilterQuery] = useState("");
+  const [sortState, setSortState] = useState<SortState | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+
+  const datasetRows = dataset?.rows ?? [];
+  const filteredRows = useMemo(() => filterRows(datasetRows, filterQuery), [datasetRows, filterQuery]);
+  const sortedRows = useMemo(() => {
+    if (!sortState) {
+      return filteredRows;
+    }
+    return sortRows(filteredRows, sortState.columnIndex, sortState.direction);
+  }, [filteredRows, sortState]);
+
+  useEffect(() => {
+    setScrollTop(0);
+    if (viewportRef.current) {
+      viewportRef.current.scrollTop = 0;
+    }
+  }, [sortedRows]);
+
+  useEffect(() => {
+    setFilterQuery("");
+    setSortState(null);
+  }, [dataset?.uploadedAt]);
+
+  const visibleRowCapacity = Math.max(
+    0,
+    Math.min(sortedRows.length, previewCount + VIRTUAL_BUFFER_ROWS)
+  );
+  const maxStartIndex = Math.max(0, sortedRows.length - visibleRowCapacity);
+  const currentStartIndex = Math.min(maxStartIndex, Math.floor(scrollTop / ROW_HEIGHT));
+  const endIndex = Math.min(sortedRows.length, currentStartIndex + visibleRowCapacity);
+  const visibleRows = sortedRows.slice(currentStartIndex, endIndex);
+  const topSpacerHeight = currentStartIndex * ROW_HEIGHT;
+  const bottomSpacerHeight = Math.max(0, (sortedRows.length - endIndex) * ROW_HEIGHT);
+  const tableViewportHeight = previewCount * ROW_HEIGHT;
+
+  const handleFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) {
+        return;
+      }
+
+      uploadDataset(file);
+      event.target.value = "";
+    },
+    [uploadDataset]
+  );
+
+  const handleScroll = useCallback(() => {
+    if (!viewportRef.current) {
+      return;
+    }
+
+    setScrollTop(viewportRef.current.scrollTop);
+  }, []);
+
+  const toggleSort = useCallback((columnIndex: number) => {
+    setSortState((current) => {
+      if (!current || current.columnIndex !== columnIndex) {
+        return { columnIndex, direction: "asc" };
+      }
+
+      if (current.direction === "asc") {
+        return { columnIndex, direction: "desc" };
+      }
+
+      return null;
+    });
+  }, []);
+
+  const hasRows = Boolean(sortedRows.length);
+  const columnCount = dataset?.headers.length ?? 1;
+
   return (
     <main className="app-shell">
-      <section className="hero">
-        <p className="eyebrow">Interactive Table</p>
-        <h1>Data at a glance, pipes that keep it honest.</h1>
+      <header className="hero">
+        <p className="eyebrow">Issue #3 · Interactive table</p>
+        <h1>Inspect data at scale with sorting, filtering, and virtualization.</h1>
         <p>
-          We are scaffolding a responsive table that honors CSV uploads, surface-level filtering, and
-          virtualization for large datasets. Everything is wired for predictable state and quick
-          deployments.
+          Upload a CSV or TSV, then glance at row counts, column meta, and interact with the table without
+          pagination.
         </p>
+      </header>
+
+      <section className="panel-grid">
+        <article className="panel upload-panel">
+          <div className="panel-heading">
+            <h2>Upload a CSV or TSV file</h2>
+            <p>Parsing happens entirely in the browser—no back-end needed.</p>
+          </div>
+          <label className="file-input" htmlFor="file-upload">
+            <span>Choose a file</span>
+            <input
+              id="file-upload"
+              type="file"
+              accept=".csv,text/csv,.tsv,text/tab-separated-values"
+              onChange={handleFileChange}
+            />
+          </label>
+          <p className="helper-text">We mirror the most recent dataset plus preview settings into localStorage.</p>
+          {loading && <p className="status">Parsing your dataset…</p>}
+          {error && (
+            <p className="status status-error" role="alert">
+              {error}
+            </p>
+          )}
+          {state.uploadedAt && (
+            <p className="status status-info">Last saved {new Date(state.uploadedAt).toLocaleString()}</p>
+          )}
+        </article>
+
+        <article className="panel summary-panel">
+          <div className="panel-heading">
+            <h2>Dataset summary</h2>
+            <p>Row count, column types, and the sample values we’ll show in the viewport.</p>
+          </div>
+          {dataset ? (
+            <>
+              <div className="summary-grid">
+                <div>
+                  <p className="label">Rows</p>
+                  <p className="value">{dataset.rowCount}</p>
+                </div>
+                <div>
+                  <p className="label">Columns</p>
+                  <p className="value">{dataset.headers.length}</p>
+                </div>
+                <div>
+                  <p className="label">Preview rows</p>
+                  <div className="preview-control">
+                    <label htmlFor="preview-count">Show</label>
+                    <select
+                      id="preview-count"
+                      value={previewCount}
+                      onChange={(event) => updatePreviewCount(Number(event.target.value))}
+                    >
+                      {PREVIEW_OPTIONS.map((count) => (
+                        <option key={count} value={count}>
+                          {count}
+                        </option>
+                      ))}
+                    </select>
+                    <span>rows</span>
+                  </div>
+                </div>
+              </div>
+
+              <ul className="column-meta">
+                {dataset.columnMeta.map((column) => (
+                  <li key={column.name}>
+                    <span className="column-name">{column.name}</span>
+                    <span className="column-type">{column.type}</span>
+                    <span className="column-sample">{column.sample || "—"}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <p className="filtered-state" aria-live="polite">
+                Showing {sortedRows.length} row{sortedRows.length === 1 ? "" : "s"} matching the current filter.
+              </p>
+            </>
+          ) : (
+            <p className="placeholder">No dataset yet—upload a CSV to inspect your columns.</p>
+          )}
+        </article>
       </section>
 
-      <section className="feature-list">
-        <h2>Built for the plan</h2>
-        <ul>
-          {features.map((feature) => (
-            <li key={feature}>{feature}</li>
-          ))}
-        </ul>
+      <section className="panel preview-panel">
+        <div className="panel-heading">
+          <h2>Interactive table</h2>
+          <p>Sort columns, filter values, and scroll through data with virtualization.</p>
+        </div>
+        {dataset ? (
+          <>
+            <div className="table-controls">
+              <label className="table-filter" htmlFor="table-filter">
+                <span>Filter rows</span>
+                <input
+                  id="table-filter"
+                  type="search"
+                  placeholder="Search anywhere in the row"
+                  value={filterQuery}
+                  onChange={(event) => setFilterQuery(event.target.value)}
+                />
+              </label>
+              <p className="row-count" aria-live="polite">
+                {hasRows ? `Showing ${sortedRows.length} of ${dataset.rowCount} rows.` : "No rows match the filter."}
+              </p>
+            </div>
+
+            {hasRows ? (
+              <div
+                className="table-viewport"
+                ref={viewportRef}
+                onScroll={handleScroll}
+                style={{ height: `${tableViewportHeight}px` }}
+              >
+                <table>
+                  <thead>
+                    <tr>
+                      {dataset.headers.map((header, columnIndex) => {
+                        const isActiveSort = sortState?.columnIndex === columnIndex;
+                        const direction = isActiveSort ? sortState?.direction : null;
+                        const indicator = direction === "asc" ? "▲" : direction === "desc" ? "▼" : "↕";
+
+                        return (
+                          <th key={header}>
+                            <button
+                              type="button"
+                              className={`column-sort ${isActiveSort ? "is-sorted" : ""}`}
+                              onClick={() => toggleSort(columnIndex)}
+                              aria-sort={isActiveSort ? direction : "none"}
+                            >
+                              <span>{header}</span>
+                              <span className="sort-indicator" aria-hidden="true">
+                                {indicator}
+                              </span>
+                            </button>
+                          </th>
+                        );
+                      })}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {topSpacerHeight > 0 && (
+                      <tr className="spacer-row" aria-hidden="true" style={{ height: topSpacerHeight }}>
+                        <td colSpan={columnCount} />
+                      </tr>
+                    )}
+
+                    {visibleRows.map((row, rowIndex) => (
+                      <tr key={`${currentStartIndex + rowIndex}-${rowIndex}`}>
+                        {dataset.headers.map((header, columnIndex) => (
+                          <td key={`${header}-${currentStartIndex + rowIndex}-${columnIndex}`}>{row[columnIndex] ?? ""}</td>
+                        ))}
+                      </tr>
+                    ))}
+
+                    {bottomSpacerHeight > 0 && (
+                      <tr className="spacer-row" aria-hidden="true" style={{ height: bottomSpacerHeight }}>
+                        <td colSpan={columnCount} />
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p className="placeholder">No rows to show for the given filter.</p>
+            )}
+          </>
+        ) : (
+          <p className="placeholder">Interactive table will appear once you upload data.</p>
+        )}
       </section>
     </main>
   );

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -2,10 +2,10 @@ import { render, screen } from "@testing-library/react";
 import App from "../App";
 
 describe("App shell", () => {
-  it("renders the hero headline and feature list", () => {
+  it("renders the hero headline and upload controls", () => {
     render(<App />);
 
-    expect(screen.getByRole("heading", { name: /data at a glance/i })).toBeInTheDocument();
-    expect(screen.getAllByRole("listitem")).toHaveLength(4);
+    expect(screen.getByRole("heading", { name: /Inspect data at scale/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Choose a file/i)).toBeInTheDocument();
   });
 });

--- a/src/hooks/useTableState.ts
+++ b/src/hooks/useTableState.ts
@@ -1,0 +1,51 @@
+import { useCallback, useState } from "react";
+import { loadPersistedState, parseCSV, savePersistedState, PersistedState } from "../services/dataService";
+
+export function useTableState() {
+  const [state, setState] = useState<PersistedState>(() => loadPersistedState());
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const uploadDataset = useCallback(async (file: File) => {
+    setError(null);
+    setLoading(true);
+
+    try {
+      const text = await file.text();
+      const dataset = parseCSV(text);
+      setState((prev) => {
+        const nextState: PersistedState = {
+          ...prev,
+          dataset,
+          uploadedAt: new Date().toISOString(),
+        };
+        savePersistedState(nextState);
+        return nextState;
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to parse the file";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const updatePreviewCount = useCallback((previewRowCount: number) => {
+    setState((prev) => {
+      const nextState: PersistedState = {
+        ...prev,
+        ui: { ...prev.ui, previewRowCount },
+      };
+      savePersistedState(nextState);
+      return nextState;
+    });
+  }, []);
+
+  return {
+    state,
+    uploadDataset,
+    updatePreviewCount,
+    loading,
+    error,
+  };
+}

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -1,0 +1,155 @@
+export type ColumnType = "number" | "boolean" | "text" | "empty";
+
+export interface ColumnMeta {
+  name: string;
+  type: ColumnType;
+  sample: string;
+}
+
+export interface ParsedDataset {
+  headers: string[];
+  rows: string[][];
+  columnMeta: ColumnMeta[];
+  rowCount: number;
+}
+
+export interface UIState {
+  previewRowCount: number;
+}
+
+export interface PersistedState {
+  dataset: ParsedDataset | null;
+  ui: UIState;
+  uploadedAt?: string;
+}
+
+const STATE_KEY = "interactive-table:state";
+const DEFAULT_UI_STATE: UIState = { previewRowCount: 5 };
+
+export function parseCSV(raw: string): ParsedDataset {
+  const normalized = raw.trim();
+  if (!normalized) {
+    throw new Error("Uploaded file is empty");
+  }
+
+  const lines = normalized.split(/\r?\n/).map((line) => line.trim());
+  const headerLine = lines.shift();
+  if (!headerLine) {
+    throw new Error("Missing header row");
+  }
+
+  const delimiter = detectDelimiter(headerLine);
+  const headers = splitRow(headerLine, delimiter).filter((value) => value.length > 0);
+  if (!headers.length) {
+    throw new Error("Headers could not be parsed");
+  }
+
+  const rows = lines
+    .filter((line) => line.length > 0)
+    .map((line) => splitRow(line, delimiter))
+    .map((row) => padRow(row, headers.length));
+
+  const meaningfulRows = rows.filter((row) => row.some((cell) => cell !== ""));
+
+  const columnMeta = headers.map((header, index) => {
+    const columnValues = meaningfulRows.map((row) => row[index] ?? "");
+    const type = detectColumnType(columnValues);
+    const sample = columnValues.find((cell) => cell !== "") ?? "";
+    return { name: header, type, sample };
+  });
+
+  return {
+    headers,
+    rows: meaningfulRows,
+    rowCount: meaningfulRows.length,
+    columnMeta,
+  };
+}
+
+export function loadPersistedState(): PersistedState {
+  if (typeof localStorage === "undefined") {
+    return getDefaultState();
+  }
+
+  const raw = localStorage.getItem(STATE_KEY);
+  if (!raw) {
+    return getDefaultState();
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      dataset: parsed.dataset ?? null,
+      ui: { ...DEFAULT_UI_STATE, ...parsed.ui },
+      uploadedAt: parsed.uploadedAt,
+    };
+  } catch (error) {
+    localStorage.removeItem(STATE_KEY);
+    return getDefaultState();
+  }
+}
+
+export function savePersistedState(state: PersistedState) {
+  if (typeof localStorage === "undefined") {
+    return;
+  }
+
+  localStorage.setItem(STATE_KEY, JSON.stringify(state));
+}
+
+function getDefaultState(): PersistedState {
+  return { dataset: null, ui: { ...DEFAULT_UI_STATE }, uploadedAt: undefined };
+}
+
+function detectDelimiter(line: string): string {
+  const counts: Record<string, number> = {
+    "\t": (line.match(/\t/g) ?? []).length,
+    ",": (line.match(/,/g) ?? []).length,
+    ";": (line.match(/;/g) ?? []).length,
+  };
+
+  const winners = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+  if (winners.length && winners[0][1] > 0) {
+    return winners[0][0];
+  }
+
+  return ",";
+}
+
+function splitRow(line: string, delimiter: string) {
+  return line.split(delimiter).map((value) => value.trim());
+}
+
+function padRow(row: string[], length: number) {
+  if (row.length === length) {
+    return row;
+  }
+
+  if (row.length > length) {
+    return row.slice(0, length);
+  }
+
+  return [...row, ...Array(length - row.length).fill("")];
+}
+
+function detectColumnType(values: string[]): ColumnType {
+  const trimmed = values.map((value) => value.trim()).filter((value) => value.length > 0);
+  if (!trimmed.length) {
+    return "empty";
+  }
+
+  const allBoolean = trimmed.every((value) => {
+    const normalized = value.toLowerCase();
+    return normalized === "true" || normalized === "false";
+  });
+  if (allBoolean) {
+    return "boolean";
+  }
+
+  const allNumbers = trimmed.every((value) => !Number.isNaN(Number(value)));
+  if (allNumbers) {
+    return "number";
+  }
+
+  return "text";
+}

--- a/src/utils/__tests__/tableData.test.ts
+++ b/src/utils/__tests__/tableData.test.ts
@@ -1,0 +1,33 @@
+import { filterRows, sortRows } from "../tableData";
+
+describe("tableData utilities", () => {
+  const rows = [
+    ["Apple", "10"],
+    ["Banana", "2"],
+    ["Cherry", "30"],
+    ["Banana split", "20"],
+  ];
+
+  it("filters rows by query across columns", () => {
+    const filtered = filterRows(rows, "ban");
+    expect(filtered).toHaveLength(2);
+    expect(filtered).toEqual(expect.arrayContaining([rows[1], rows[3]]));
+  });
+
+  it("returns the original rows when the query is empty", () => {
+    const filtered = filterRows(rows, "");
+    expect(filtered).toBe(rows);
+  });
+
+  it("sorts rows numerically for numeric-like values", () => {
+    const sorted = sortRows(rows, 1, "asc");
+    expect(sorted[0]).toEqual(rows[1]);
+    expect(sorted[sorted.length - 1]).toEqual(rows[2]);
+  });
+
+  it("sorts rows descending when requested", () => {
+    const sorted = sortRows(rows, 1, "desc");
+    expect(sorted[0]).toEqual(rows[2]);
+    expect(sorted[sorted.length - 1]).toEqual(rows[1]);
+  });
+});

--- a/src/utils/tableData.ts
+++ b/src/utils/tableData.ts
@@ -1,0 +1,56 @@
+export type SortDirection = "asc" | "desc";
+
+const FALLBACK_LOCALE = "en";
+
+export function filterRows(rows: string[][], query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return rows;
+  }
+
+  return rows.filter((row) => row.some((cell) => cell.toLowerCase().includes(normalizedQuery)));
+}
+
+export function sortRows(rows: string[][], columnIndex: number, direction: SortDirection) {
+  const sorted = [...rows];
+  const factor = direction === "asc" ? 1 : -1;
+
+  sorted.sort((rowA, rowB) => {
+    const valueA = rowA[columnIndex] ?? "";
+    const valueB = rowB[columnIndex] ?? "";
+    const comparison = compareCells(valueA, valueB);
+    if (comparison === 0) {
+      return 0;
+    }
+    return comparison * factor;
+  });
+
+  return sorted;
+}
+
+function compareCells(left: string, right: string) {
+  const a = left.trim();
+  const b = right.trim();
+
+  if (!a && !b) {
+    return 0;
+  }
+
+  if (!a) {
+    return 1;
+  }
+
+  if (!b) {
+    return -1;
+  }
+
+  const numericA = Number(a);
+  const numericB = Number(b);
+
+  const bothNumeric = !Number.isNaN(numericA) && !Number.isNaN(numericB);
+  if (bothNumeric) {
+    return numericA - numericB;
+  }
+
+  return a.localeCompare(b, FALLBACK_LOCALE, { numeric: true, sensitivity: "base" });
+}


### PR DESCRIPTION
## Summary\n- add dataset ingestion + persistence so uploads and preview settings survive refreshes\n- replace the placeholder feature list with an interactive table that supports sorting, filtering, and virtualization driven by the preview count selector\n- add utility helpers (and tests) for filtering/sorting to keep logic testable\n\n## Testing\n- npm test\n\nCloses #3